### PR TITLE
Add packet length check

### DIFF
--- a/Vorpal-Hexapod-Robot/Vorpal-Hexapod-Robot.ino
+++ b/Vorpal-Hexapod-Robot/Vorpal-Hexapod-Robot.ino
@@ -1450,6 +1450,9 @@ int receiveDataHandler() {
         break;
       case P_WAITING_FOR_LENGTH:
         { // need scope for local variables
+            if (c > MAXPACKETDATA){
+              return 0;
+            }
             packetLength = c;
             packetLengthReceived = 0;
             packetState = P_READING_DATA;

--- a/Vorpal-Hexapod-Robot/Vorpal-Hexapod-Robot.ino
+++ b/Vorpal-Hexapod-Robot/Vorpal-Hexapod-Robot.ino
@@ -1451,7 +1451,8 @@ int receiveDataHandler() {
       case P_WAITING_FOR_LENGTH:
         { // need scope for local variables
             if (c > MAXPACKETDATA){
-              return 0;
+              packetErrorChirp(c);
+              break;
             }
             packetLength = c;
             packetLengthReceived = 0;


### PR DESCRIPTION
Hey guys, Thank you for making you awesome robot open source.

I've found a small but annoying bug, I'm developing an Android app (early stages) that replaces the game pad [if you're interested](https://github.com/shakram02/Vorpal-Hexapod-Controller). Sometimes the Arduino went just irresponsive. 

## Meat and butter

Tracking what happens I found that sometimes the bluetooth packet arrives in pieces, And eventually make  the packet length invalid (i.e larger than 48), which makes writes that are out of the legitimate memory locations.